### PR TITLE
Fix gemspec syntax

### DIFF
--- a/vagrant-aws.gemspec
+++ b/vagrant-aws.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "fog-aws", "~> 3.0"
   # pinned to be compatible with vagrant-vsphere version 1.13.5 and 1.14.0
-  s.add_runtime_dependency "nokogiri", "-> 1.10.0"
+  s.add_runtime_dependency "nokogiri", "~> 1.10.0"
   s.add_runtime_dependency "iniparse", "~> 1.4", ">= 1.4.2"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
Fixing the following issue:

```
$ bundle

[!] There was an error parsing `Gemfile`: 
[!] There was an error while loading `vagrant-aws.gemspec`: Illformed requirement ["-> 1.10.0"]. Bundler cannot continue.

 #  from /tmp/vagrant-aws/vagrant-aws.gemspec:22
 #  -------------------------------------------
 #    # pinned to be compatible with vagrant-vsphere version 1.13.5 and 1.14.0
 >    s.add_runtime_dependency "nokogiri", "-> 1.10.0"
 #    s.add_runtime_dependency "iniparse", "~> 1.4", ">= 1.4.2"
 #  -------------------------------------------

Bundler cannot continue.
```